### PR TITLE
fix: add dotnet restore before EF Core migrations in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -212,6 +212,9 @@ jobs:
     - name: Add dotnet tools to PATH
       run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
 
+    - name: Restore dependencies
+      run: dotnet restore SmartMenuOptim.API/SmartMenuOptim.API.csproj
+
     - name: Apply EF Core Migrations
       env:
         ConnectionStrings__DefaultConnection: "Host=localhost;Port=5432;Database=SmartMenuDb;Username=postgres;Password=admin123"
@@ -268,6 +271,9 @@ jobs:
 
     - name: Add dotnet tools to PATH
       run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+
+    - name: Restore dependencies
+      run: dotnet restore SmartMenuOptim.API/SmartMenuOptim.API.csproj
 
     - name: Apply EF Core Migrations to Azure PostgreSQL
       env:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Cross-cutting, technology-facing concerns applied across the App Features above.
 | Feature | Description | Technical docs |
 |---------|-------------|----------------|
 | **Clean modular architecture** | Separation of concerns across Web Client, API, AI/Analytics, Messaging, Infrastructure, Security, and Monitoring layers. | [README.md](README.md#initial-project-structure) |
-| **Event-driven asynchronous workflows** | Background processing for analytics and notifications using messaging/event-based patterns and Azure integrations. | [README.md](README.md#high-level-smart-menu-optimizer-system-design) |
-| **Identity and access control** | Enterprise-ready authentication/authorization options (Azure AD/Entra ID, OAuth2/OIDC, JWT, ASP.NET Core Identity, RBAC, policy-based auth). | [README.md](README.md#technology-stack) |
+| **Event-driven asynchronous workflows** | Background processing for analytics and notifications using messaging/event-based patterns and Azure integrations. | [README.md](README.md#high-level-system-design) |
+| **Identity and access control** | Enterprise-ready authentication/authorization options (Azure AD/Entra ID, OAuth2/OIDC, JWT, ASP.NET Core Identity, RBAC, policy-based auth). | [README.md](README.md#tech-stack) |
 | **Cloud-native observability** | Telemetry, health monitoring, distributed tracing, and alerting using Azure Application Insights/Azure Monitor. | [README.md](README.md#monitoring--logging) |
 | **CI/CD-ready delivery** | GitHub Actions pipeline model for build, test, package, deploy, and release governance. | [README.md](README.md#cicd-pipeline) |
 | **Extensible AI service model** | Supports Azure Cognitive Services and optional custom ML pipelines for tenant-specific forecasting/recommendation evolution. | [README.md](README.md#ai-features) |

--- a/README.md
+++ b/README.md
@@ -1,400 +1,119 @@
 # Smart Menu Optimizer
 
-## Project Fundation
+[![.NET 8](https://img.shields.io/badge/.NET-8.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
+[![Blazor Server](https://img.shields.io/badge/Blazor-Server-512BD4?logo=blazor)](https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor)
+[![ASP.NET Core Web API](https://img.shields.io/badge/API-ASP.NET_Core-5C2D91?logo=dotnet)](https://learn.microsoft.com/aspnet/core/web-api/)
+[![Azure AI](https://img.shields.io/badge/Azure-AI_Services-0078D4?logo=microsoftazure)](https://azure.microsoft.com/products/ai-services/)
+[![PostgreSQL](https://img.shields.io/badge/Database-PostgreSQL-4169E1?logo=postgresql)](https://www.postgresql.org/)
 
-**Smart Menu Optimizer** is an Azure-native, AI-powered SaaS platform designed to help restaurant managers and staff make data-driven decisions about their menus. This project demonstrates expertise in building secure, scalable, and maintainable cloud solutions with a modern .NET stack, advanced analytics, and a seamless user experience.
-
-The platform delivers actionable insights by analyzing sales trends and customer feedback, automatically recommending top-performing dishes and menu adjustments using state-of-the-art AI. It is architected for multitenancy, supporting multiple restaurants or brands within a single solution, and is built for extensibility and real-world SaaS best practices.
-
----
-
-## 🎯 Project Goals
-
-- **AI-Driven Menu Optimization**  
-  Empower restaurants to maximize revenue and guest satisfaction by leveraging AI/ML to analyze historical sales data and customer reviews. Automatically surface recommendations to promote best sellers, retire under-performers, and adjust menus in real time.
-
-- **Robust, Scalable Backend (ASP.NET Core Web API)**  
-  Provide a reliable, multi-tenant API for menu, order, and analytics management, with secure RESTful endpoints and modular business logic.
-
-- **Responsive, Real-Time Web UI (Blazor Server)**  
-  Deliver an interactive dashboard for managers and staff, featuring real-time updates, visual analytics, and seamless user workflows.
-
-- **Deep AI Integration**  
-  Seamlessly integrate Azure Cognitive Services (Text Analytics, OpenAI, Language) and/or custom ML models (via Azure Machine Learning) to deliver natural language understanding, predictive analytics, and automated menu recommendations.
-
-- **Clean, Modular Architecture**  
-  Follow clean architecture principles and separation of concerns to ensure maintainability, testability, and extensibility. Built-in support for tenant-aware data isolation enables SaaS scalability across brands and restaurants.
-
-- **Rich Data Visualization**  
-  Use advanced charting libraries (e.g., ChartJS, Syncfusion, Telerik) within Blazor to present trends, forecasts, and KPIs in visually compelling formats.
-
-- **Azure-Native SaaS Best Practices**  
-  Employ secure authentication, scalable hosting (Azure App Service), centralized secrets management (Key Vault), and full-stack observability (Application Insights, Azure Monitor).
-
-- **Identity & Security**  
-  Ensure robust authentication, authorization, and secure access control for all users and integrations. Apply multi-layered security best practices for SaaS and enterprise environments.
-
-- **Asynchronous, Event-Driven Processing**  
-  Showcase event-driven and asynchronous workflows for scalable AI analytics and notifications, leveraging Azure Functions and background job processing.
-
-- **Top-Tier Developer Experience**  
-  Provide clear, well-documented APIs (OpenAPI/Swagger), support for third-party integrations, and a maintainable, extensible codebase.
+**What this app does:** Smart Menu Optimizer is an Azure-native, AI-powered SaaS platform that helps restaurant managers make data-driven menu decisions by analyzing sales trends and customer feedback, then suggesting top-performing dishes and menu adjustments.
 
 ---
 
-## 🚀 The demo will showcase proficiency with:
+## Features
 
-- **ASP.NET Core Web API:**  
-  Building robust, scalable backend services for menu, order, and analytics management, exposing RESTful endpoints for data access and business logic.
+### App Features
 
-- **Blazor Server:**  
-  Delivering a responsive, real-time web UI for restaurant managers and staff, enabling interactive dashboards, visual analytics, and seamless user experiences.
+Domain-facing capabilities — what restaurant teams can do with the platform.
 
-- **Integration with AI:**  
-  Leveraging Azure Cognitive Services (Text Analytics, OpenAI, Language) and/or custom ML models (via Azure Machine Learning) to power natural language insights, predictive analytics, and automated recommendations.
+| Feature | Description | Docs |
+|---------|-------------|------|
+| **AI-driven menu optimization** | Analyze historical sales and customer sentiment to recommend dish promotions, pricing tweaks, and menu adjustments that improve revenue and guest satisfaction. | [README.md](README.md#ai-features) |
+| **Interactive dashboards** | Real-time KPI and trend dashboards for managers and staff, including actionable summaries and visual analytics. | [README.md](README.md#demo-highlights) |
+| **Sales trend prediction** | Forecast upcoming dish-level performance and identify likely growth or decline patterns before service periods. | [README.md](README.md#ai-features) |
+| **Natural language insights** | Ask business questions in plain language (for example: “What should I promote next week?”) and receive AI-generated recommendations. | [README.md](README.md#ai-features) |
+| **Tenant-aware SaaS experience** | Multi-restaurant/tenant data isolation with tenant context propagated across API, analytics, and storage layers. | [README.md](README.md#initial-project-structure) |
+| **Sentiment-informed decisions** | Use review sentiment analysis to detect dish satisfaction trends and support menu improvement decisions. | [README.md](README.md#ai-features) |
 
-- **Clean Architecture & Multitenancy-Ready Design:**  
-  Architecting the system with separation of concerns, modular service layers, and tenant-aware data isolation to support multiple restaurants or brands within the same SaaS platform.
+### Technical Features
 
-- **Charting and Interactive UI:**  
-  Incorporating rich data visualizations using charting libraries (e.g., ChartJS, Syncfusion, or Telerik for Blazor) to display trends, forecasts, and actionable metrics for end-users.
+Cross-cutting, technology-facing concerns applied across the App Features above.
 
-- **Azure-Native SaaS Best Practices:**  
-  Demonstrating secure authentication, scalable hosting (App Service), and observability (Application Insights, Monitor).
+| Feature | Description | Technical docs |
+|---------|-------------|----------------|
+| **Clean modular architecture** | Separation of concerns across Web Client, API, AI/Analytics, Messaging, Infrastructure, Security, and Monitoring layers. | [README.md](README.md#initial-project-structure) |
+| **Event-driven asynchronous workflows** | Background processing for analytics and notifications using messaging/event-based patterns and Azure integrations. | [README.md](README.md#high-level-smart-menu-optimizer-system-design) |
+| **Identity and access control** | Enterprise-ready authentication/authorization options (Azure AD/Entra ID, OAuth2/OIDC, JWT, ASP.NET Core Identity, RBAC, policy-based auth). | [README.md](README.md#technology-stack) |
+| **Cloud-native observability** | Telemetry, health monitoring, distributed tracing, and alerting using Azure Application Insights/Azure Monitor. | [README.md](README.md#monitoring--logging) |
+| **CI/CD-ready delivery** | GitHub Actions pipeline model for build, test, package, deploy, and release governance. | [README.md](README.md#cicd-pipeline) |
+| **Extensible AI service model** | Supports Azure Cognitive Services and optional custom ML pipelines for tenant-specific forecasting/recommendation evolution. | [README.md](README.md#ai-features) |
 
-- **Identity & Security:**  
-  Implementing industry-standard authentication and authorization for users and APIs, including multi-factor authentication, RBAC, secrets management, and secure data access.
+---
 
-- **Event-Driven & Asynchronous Processing:**  
-  Showcasing event-driven patterns using Azure Functions/Logic Apps for decoupled, scalable AI analytics and notification workflows.
+## Project Goals
 
-- **Developer Experience:**  
-  Providing clear API documentation, support for third-party integrations, and maintainable codebase structure for extensibility.
+| Goal | Description |
+|------|-------------|
+| **AI-Driven Menu Optimization** | Use AI/ML to analyze sales and feedback, then surface recommendations that maximize revenue and customer satisfaction. |
+| **Scalable Backend** | Deliver reliable multi-tenant APIs for menu, order, and analytics operations with secure RESTful interfaces. |
+| **Responsive Real-Time UI** | Provide Blazor-based dashboards with live updates and actionable visual insights for operations teams. |
+| **Deep AI Integration** | Integrate Azure OpenAI, Text Analytics, Language services, and optional Azure ML custom models for prediction and insight generation. |
+| **Clean Architecture** | Maintain testable, modular components and strong separation of concerns for long-term extensibility. |
+| **Azure-Native SaaS Best Practices** | Apply secure auth, scalable hosting, secrets management, and full-stack observability across environments. |
+| **Security & Identity** | Enforce robust authentication, authorization, and tenant-aware access controls across all services. |
+| **Event-Driven Processing** | Enable asynchronous analytics and notifications via decoupled messaging patterns and background jobs. |
+| **Developer Experience** | Support maintainability, clear API documentation, and straightforward integration pathways for future growth. |
 
 ---
 
 ## Demo Highlights
 
-- **Multi-Restaurant Demo**: Easily switch between tenants to view isolated data and recommendations.
-- **Interactive Dashboards**: Real-time analytics and actionable insights, powered by AI.
-- **Natural Language Insights**: Summarize trends and receive recommendations as plain-language suggestions.
-- **Seamless Operations**: Fast, secure, and reliable—even as the platform scales.
+- **Multi-Restaurant Demo**: Switch between tenants while preserving strict data isolation.
+- **Interactive Dashboards**: Real-time analytics with actionable AI recommendations.
+- **Natural Language Insights**: Ask business questions and receive plain-language decision guidance.
+- **Seamless Operations**: Fast, secure, resilient user workflows as platform load scales.
 
 ---
 
-## Technology Stack
+## Tech Stack
 
-- **Backend:** ASP.NET Core Web API  
-- **Frontend:** Blazor Server  
-- **AI & Analytics:** Azure Cognitive Services, Azure Machine Learning (optional)  
-- **Database:** Azure PostgreSQL, Azure Redis, Azure Blob Storage  
+| Layer | Technology | Purpose |
+|-------|-----------|---------|
+| **Backend API** | ASP.NET Core Web API | Business logic, tenant-aware endpoints, analytics orchestration |
+| **Frontend** | Blazor Server | Interactive real-time UI for management dashboards |
+| **AI & Analytics** | Azure Cognitive Services, Azure OpenAI, optional Azure Machine Learning | Forecasting, sentiment analysis, recommendations, natural language interactions |
+| **Database** | Azure Database for PostgreSQL | Core relational persistence for tenant business data |
+| **Caching** | Azure Cache for Redis | Low-latency access for frequently used metrics/configurations |
+| **Object Storage** | Azure Blob Storage | Unstructured data storage, exports, artifacts, backups |
+| **Identity & Auth** | Entra ID (Azure AD), OAuth2/OIDC, JWT, ASP.NET Core Identity, IdentityServer (optional) | Authentication, authorization, policy enforcement |
+| **Observability** | Azure Application Insights, Azure Monitor, Log Analytics | Monitoring, diagnostics, alerting, telemetry analysis |
+| **Messaging/Eventing** | Azure Service Bus, Event Grid, optional Event Hubs | Asynchronous processing and decoupled integration |
+| **CI/CD** | GitHub Actions | Automated build-test-package-deploy workflows |
 
-- **Identity & Security:**  
-  Choose the best fit for authentication and authorization requirements:
-  - **Azure Active Directory (Entra ID):**  
-    Enterprise-grade authentication and RBAC for users and admins, seamless Azure and Microsoft 365 integration.
-  - **OAuth2/OpenID Connect Providers:**  
-    Support for Auth0, Okta, Google Identity, or custom OIDC servers for broader SaaS or B2C scenarios.
-  - **IdentityServer (Duende):**  
-    Self-hosted, customizable Identity and Authorization server; ideal for advanced multi-tenancy, federation, or hybrid deployments.
-  - **ASP.NET Core Identity:**  
-    Out-of-the-box membership system for custom user stores, local accounts, roles, and claims-based authorization.
-  - **JWT Bearer Authentication:**  
-    Stateless, token-based authentication for APIs, suitable for SPAs and mobile integrations.
-  - **Role-Based Access Control (RBAC):**  
-    Enforce permissions by user role, claims, or policies at the API and data layers.
-  - **Claims-Based & Policy-Based Authorization:**  
-    Enable fine-grained, context-aware access control, supporting multi-tenancy and complex business rules.
-  - **Azure Key Vault:**  
-    Secure cloud-based storage for secrets, keys, and certificates, integrated with managed identities.
+### Authentication and Authorization Options
 
-- **Observability:** Azure Application Insights, Azure Monitor
+- **Azure Active Directory (Entra ID):** Enterprise-grade SSO and RBAC.
+- **OAuth2/OpenID Connect Providers:** Auth0, Okta, Google Identity, or custom OIDC providers.
+- **IdentityServer (Duende):** Self-hosted identity for advanced federation scenarios.
+- **ASP.NET Core Identity:** Local-account and role/claims support.
+- **JWT Bearer Authentication:** Token-based auth for APIs/SPAs/mobile.
+- **RBAC + Policy-based Authorization:** Fine-grained, tenant-aware control.
+- **Azure Key Vault:** Secure secret, key, and certificate management.
 
 ---
 
-## Why This Project?
+## Architecture
 
-This project is a comprehensive demonstration of modern Azure SaaS development, blending real-world business value (menu optimization and sales uplift) with platform engineering best practices. It highlights not only technical proficiency, but also architectural clarity, operational excellence, and a focus on delivering measurable outcomes for end-users.
+### Layered Architecture Overview
 
-## AI Features
+The solution follows a layered, modular architecture:
 
-<img width="509" height="216" alt="image" src="https://github.com/user-attachments/assets/9692464c-9ce9-47f0-aff5-c7aa06fc31ea" />
+1. **Web Client (Blazor Server)**
+   - Tenant-aware UI, role-based access, real-time visual analytics.
+2. **API Layer (ASP.NET Core Web API)**
+   - Secure REST endpoints, business rules, and orchestration.
+3. **AI/Analytics Services**
+   - Forecasting, sentiment analysis, dish scoring, recommendation workflows.
+4. **Event Bus/Messaging Layer**
+   - Decoupled asynchronous triggers and background processing.
+5. **Data Storage Layer**
+   - PostgreSQL (transactional), Blob Storage (unstructured), Redis (cache).
+6. **Security & Identity**
+   - AuthN/AuthZ, tenant propagation, secrets, policy enforcement.
+7. **Monitoring & Observability**
+   - Logs, traces, metrics, alerts across all components.
 
-- **Natural Language Insights:**  
-  Ask, "What should I promote next week?" — AI responds using mock ML data.  
-  *This feature leverages Azure OpenAI Service or Azure Cognitive Services Language to interpret and answer natural language queries. Users can interact with the system conversationally to receive actionable recommendations based on sales and sentiment data.*
-
-- **Sales Trend Prediction:**  
-  Show predictions for next week's sales per dish.  
-  *Utilizes Azure Machine Learning or Azure Cognitive Services for forecasting future sales trends. Predictive models analyze historical sales data to identify growth opportunities and flag underperforming items, enabling data-driven menu optimization.*
-
-- **Sentiment Analysis:**  
-  Analyze customer reviews (mocked) to understand dish satisfaction.  
-  *Processes customer feedback using Azure Cognitive Services Text Analytics to extract sentiment scores and key phrases. This insight helps identify popular dishes, areas for improvement, and overall customer satisfaction trends.*
-
-- **Dish Performance Scoring:**  
-  Automatically calculates and assigns performance scores to each dish by combining sales trends, sentiment analysis, and other KPIs.  
-  *These scores are visualized in dashboards and used to drive recommendations for menu changes or promotional campaigns.*
-
-- **Automated Menu Optimization Suggestions:**  
-  The system continuously monitors all available data (sales, sentiment, inventory) and surfaces proactive suggestions to managers, such as promoting high-margin items, adjusting prices, or temporarily removing underperforming dishes.
-
-- **Interactive AI Chat & Insights:**  
-  Managers can ask open-ended questions (e.g., "What is the best dish to feature for lunch specials?") and receive AI-generated responses, with detailed reasoning and supporting metrics.
-
-- **Anomaly Detection:**  
-  AI models can spot anomalies in sales or reviews (e.g., sudden spike in negative feedback for a dish), triggering alerts and suggesting remedial actions.
-
-- **Customizable AI Models:**  
-  (Optional/Advanced) The platform can allow per-tenant customization of forecasting or recommendation models, using Azure Machine Learning pipelines.
-
----
-
-## Initial Project Structure
-
-<img width="636" height="139" alt="image" src="https://github.com/user-attachments/assets/1f607f33-6970-4065-be95-c7291e0ee0e3" />
-
-**Layered Overview (Adapted to Project Structure):**
-
-- **1. Web Client (Blazor Server)**
-  - Located in the `/WebClient` or `/UI` project folder.
-  - Delivers a modern, responsive, real-time UI.
-  - Handles authentication, tenant context, role-based access, and interactive dashboards.
-  - Communicates securely with backend APIs, visualizes analytics, and presents AI-driven recommendations.
-
-- **2. API Layer (ASP.NET Core Web API)**
-  - Found in the `/Api` or `/Server` project folder.
-  - Exposes RESTful endpoints for managing menu items, orders, reviews, and analytics.
-  - Applies business rules, enforces security, and mediates all client-backend operations.
-  - Implements clean architecture (e.g., Controllers, Services, Repositories).
-
-- **3. AI/Analytics Services**
-  - Integrated as services within the backend or as separate projects (e.g., `/AI`, `/Analytics`).
-  - Handles sales trend forecasting, dish scoring, and sentiment analysis.
-  - Calls Azure Cognitive Services (Text Analytics, OpenAI) or custom ML endpoints.
-  - Supports both synchronous (user queries) and asynchronous (event-driven) AI workflows.
-
-- **4. Event Bus/Messaging Layer**
-  - Set up as background services or infrastructure modules (e.g., `/Messaging`, `/EventBus`).
-  - Uses Azure Service Bus/Event Grid clients for scalable, decoupled communication.
-  - Ensures event-driven triggers for analytics, notifications, and background jobs.
-
-- **5. Data Storage**
-  - Database context and repository implementations are typically under `/Infrastructure` or `/Persistence`.
-  - **Azure Database for PostgreSQL:** Main relational store for all tenant data (menus, orders, reviews, analytics).
-  - **Azure Blob Storage:** For unstructured data, file uploads, and backups.
-  - **Azure Cache for Redis:** For caching frequently accessed data, boosting performance.
-
-- **6. Security & Identity**
-  - Identity and access management code resides in `/Security`, `/Identity`, or within API configuration.
-  - Integrates with Azure Active Directory for authentication/authorization and manages tenant context propagation.
-
-- **7. Monitoring & Observability**
-  - Instrumentation code and telemetry are integrated as cross-cutting concerns, using Azure Application Insights and Azure Monitor.
-  - Logging and performance tracking are accessible throughout all major layers, ensuring observability.
-
-**Extensibility & Best Practices:**
-- The structure supports adding new services or features as separate projects/folders without disrupting existing code.
-- Adheres to clean architecture: separation of presentation, business logic, infrastructure, and data.
-- Multi-tenancy is foundational, with tenant context handled at API and data layers.
-- Event-driven patterns are easily extensible for scalable, asynchronous processing.
-- Cloud-native integrations enable easy deployment and scaling on Azure.
-
----
-# Low-Level System Design (LLD): Smart Menu Optimizer  
-**With Developer Collaboration & CI/CD Automation**
-
----
-
-## 1. Component Overview
-
-- **Web Client** (`/WebClient`): Blazor Server UI
-- **API Layer** (`/Api`): ASP.NET Core Web API
-- **AI/Analytics Services** (`/AI`, `/Analytics`)
-- **Event Bus/Messaging** (`/Messaging`, `/EventBus`): Azure Service Bus
-- **Data Storage** (`/Infrastructure`, `/Persistence`): Azure PostgreSQL, Redis
-- **Security & Identity** (`/Security`, `/Identity`)
-- **Monitoring & Observability** (cross-cutting): Application Insights, Azure Monitor
-- **CI/CD & DevOps** (`/.github`, `/DevOps`): GitHub Actions, IaC scripts
-
----
-
-## 2. Developer Roles & Responsibilities
-
-| Role                  | Responsibilities                                                                                  |
-|-----------------------|--------------------------------------------------------------------------------------------------|
-| **Full Stack Dev**    | Web UI, API endpoints, integration, code review, unit/integration tests                          |
-| **AI/ML Engineer**    | AI/ML job creation, model deployment, analytics pipeline, API integration                        |
-| **DevOps Engineer**   | CI/CD pipelines, IaC (Infrastructure as Code), cloud deployment, monitoring, secrets management  |
-| **QA Engineer**       | Automated testing, test coverage, quality gates, regression/acceptance criteria                  |
-| **Tech Lead/Architect** | Design review, architecture, code review, enforce standards, release management                |
-
----
-
-## 3. Collaboration Practices
-
-- **Source Control:**  
-  - Hosted on GitHub.  
-  - Branching:  
-    - `main`: production  
-    - `develop`: staging  
-    - `feature/*`: new features  
-    - `bugfix/*`, `hotfix/*`: fixes
-- **Pull Requests:**  
-  - All changes via PRs; require code reviews and passing status checks.
-  - PR templates enforce checklists (tests, docs, code style).
-- **Code Quality:**  
-  - Static analysis (SonarCloud or dotnet analyzers) in CI.
-  - Code style enforced (e.g., dotnet-format, EditorConfig).
-- **Documentation:**  
-  - Markdown docs in `/docs` and code comments.
-  - Architecture/decision records (ADR) in `/docs/adr`.
-- **Testing:**  
-  - Unit/integration tests required for all features.
-  - Code coverage thresholds enforced in CI.
-
----
-
-## 4. CI/CD Pipeline (GitHub Actions)
-
-### Pipeline Overview
-
-- **Triggers:**  
-  - On PRs to `develop` and `main`
-  - On push to branches
-- **Stages/Jobs:**
-    1. **Build**  
-        - Restore NuGet packages  
-        - Build all projects  
-        - Linting/static analysis  
-    2. **Test**  
-        - Run all unit & integration tests  
-        - Publish code coverage report  
-        - Fail on test/code quality issues  
-    3. **Package**  
-        - Build Docker images for API, WebClient, AI/Analytics  
-        - Tag with commit SHA/version  
-        - Push to Azure Container Registry  
-    4. **Deploy**  
-        - **Staging:**  
-            - On `develop`, auto-deploy to Azure staging slots using IaC (Bicep/Terraform/ARM)  
-        - **Production:**  
-            - On `main`, require manual approval for prod deployment  
-        - Run DB migrations with rollback support  
-    5. **Notification & Observability**  
-        - Notify via Slack/Teams  
-        - Push logs/telemetry to Azure Monitor
-
----
-
-### Example: GitHub Actions Workflow
-
-```yaml
-# .github/workflows/ci-cd.yaml
-name: CI/CD
-
-on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '8.0.x'
-      - name: Build solution
-        run: dotnet build --configuration Release
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test
-        run: dotnet test --configuration Release --collect:"XPlat Code Coverage"
-
-  docker:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-      - name: Login to ACR
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ secrets.ACR_LOGIN_SERVER }}
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
-      - name: Build and push images
-        run: |
-          docker build -t ${{ secrets.ACR_LOGIN_SERVER }}/api:${{ github.sha }} ./Api
-          docker push ${{ secrets.ACR_LOGIN_SERVER }}/api:${{ github.sha }}
-
-  deploy-staging:
-    runs-on: ubuntu-latest
-    needs: docker
-    if: github.ref == 'refs/heads/develop'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Deploy to Azure Staging
-        run: |
-          az deployment group create --resource-group my-rg --template-file ./DevOps/main.bicep
-
-  deploy-prod:
-    runs-on: ubuntu-latest
-    needs: docker
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: production
-      url: ${{ steps.deploy-prod.outputs.webapp-url }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Manual Approval
-        uses: fjogeleit/yaml-update-action@v0.11.0
-      - name: Deploy to Azure Production
-        run: |
-          az deployment group create --resource-group my-rg-prod --template-file ./DevOps/main.bicep
-```
-
----
-
-## 5. Deployment & Infrastructure (IaC)
-
-- **Managed via Bicep/Terraform/ARM** in `/DevOps`
-- **Azure Resources:**
-  - App Service (Web/API/AI)
-  - Azure Container Registry
-  - Azure PostgreSQL
-  - Azure Redis
-  - Service Bus (Eventing)
-  - Key Vault (secrets)
-  - Application Insights (monitoring)
-- **Multi-Environment:**  
-  - Separate resources for dev, staging, prod  
-  - Configurations and secrets managed per environment
-- **Blue/Green Deployments:**  
-  - Slot-based for zero-downtime releases
-  - Rollback via slot swap
-
----
-
-## 6. Monitoring & Observability
-
-- **Application Insights:**  
-  - Request logs, traces, exceptions, custom metrics  
-- **Health Checks:**  
-  - `/health` endpoints polled by Azure
-- **Alerting:**  
-  - Error rates, failed deployments, resource exhaustion
-
----
-
-## 7. Directory Structure (including DevOps)
+### Initial Project Structure
 
 ```plaintext
 /WebClient
@@ -405,602 +124,140 @@ jobs:
 /Infrastructure
 /Security
 /Monitoring
-/.github/workflows     # CI/CD YAMLs
-/DevOps                # IaC scripts (Bicep/Terraform/ARM)
+/.github/workflows
+/DevOps
 /docs
 ```
 
----
+### Why this architecture
 
-## 8. System & Developer Workflow Diagrams
-
-### 8.1. CI/CD Pipeline Flow (Mermaid)
-
-<img width="3355" height="3840" alt="Untitled diagram _ Mermaid Chart-2025-08-23-181706" src="https://github.com/user-attachments/assets/f9562879-af24-4be2-b1c4-4b0c7dc73cc3" />
-
----
-
-## 9. Key LLD Principles (How They Are Met)
-
-1. **Scalability:** Modular, stateless services, auto-scaling cloud infra
-2. **Reliability:** Health checks, monitoring, automated rollback
-3. **Security:** Azure AD/JWT, Key Vault, RBAC, branch protections
-4. **Performance:** Caching, async/event-driven jobs, optimized CI
-5. **Maintainability:** Code reviews, automated testing, IaC, docs
-6. **Extensibility:** Modular projects, easy feature branch flows
-7. **Observability:** Logs, metrics, alerting
-8. **Data Isolation:** Tenant-aware DB, separate envs
-9. **Cost Efficiency:** Deployment slots, auto-scaling, teardown on cleanup
-10. **UX/Responsiveness:** SignalR, pre-cached data, preview envs
+- Supports multi-tenant SaaS growth without coupling features tightly.
+- Keeps AI/analytics extensible and independently evolvable.
+- Enables secure, observable, production-ready cloud deployments.
+- Balances delivery speed and maintainability through modular boundaries.
 
 ---
 
-**This LLD now fully integrates developer collaboration and DevOps automation as first-class citizens of the Smart Menu Optimizer platform.**
+## AI Features
+
+<img width="509" height="216" alt="image" src="https://github.com/user-attachments/assets/9692464c-9ce9-47f0-aff5-c7aa06fc31ea" />
+
+| Capability | Description |
+|------------|-------------|
+| **Natural Language Insights** | Ask questions such as “What should I promote next week?” and get AI-generated, context-aware responses.
+| **Sales Trend Prediction** | Forecast dish-level sales for upcoming periods using historical trend signals.
+| **Sentiment Analysis** | Analyze customer reviews and identify satisfaction patterns or quality concerns.
+| **Dish Performance Scoring** | Compute composite performance signals by combining sales, sentiment, and KPI data.
+| **Automated Optimization Suggestions** | Continuously surface recommendations such as promotions, price changes, and seasonal adjustments.
+| **Interactive AI Chat** | Support manager-facing conversational exploration of metrics and recommendations.
+| **Anomaly Detection** | Detect unusual events (for example, sudden negative feedback spikes) and trigger alerts.
+| **Customizable Models (Optional)** | Enable per-tenant model tuning and advanced ML pipeline customization.
 
 ---
 
-# Smart Menu Optimizer – Low-Level System Design
+## Low-Level Design (LLD) Summary
+
+Smart Menu Optimizer’s LLD includes both application internals and team delivery mechanics.
+
+### Component Scope
+
+- Web Client (`/WebClient`)
+- API Layer (`/Api`)
+- AI/Analytics (`/AI`, `/Analytics`)
+- Messaging (`/Messaging`, `/EventBus`)
+- Data (`/Infrastructure`, `/Persistence`)
+- Security (`/Security`, `/Identity`)
+- Observability (cross-cutting)
+- CI/CD & DevOps (`/.github`, `/DevOps`)
+
+### Collaboration and Delivery
+
+- GitHub flow with `main`, `develop`, `feature/*`, `bugfix/*`, `hotfix/*`.
+- Mandatory pull requests with checks and review gates.
+- Static analysis, testing, and documentation baked into delivery process.
+- IaC-driven deployments and environment-specific secrets/configurations.
+
+### CI/CD Pipeline
+
+Typical stages:
+1. **Build** — restore/build/lint
+2. **Test** — unit + integration + coverage
+3. **Package** — container image build/push
+4. **Deploy** — staging auto, production gated approval
+5. **Observe/Notify** — logs, telemetry, team notifications
 
 ---
 
-## 1. Component Overview
-
-**Main Subsystems**
-- **Web Client** (Blazor Server, `/WebClient`)
-- **API Layer** (ASP.NET Core Web API, `/Api`)
-- **AI/Analytics Services** (`/AI`, `/Analytics`)
-- **Data Storage** (`/Infrastructure`, `/Persistence`)
-- **Security & Identity** (`/Security`, `/Identity`)
-- **Monitoring & Observability** (cross-cutting)
-
----
-
-<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/e7b6c363-541c-4fb9-bb08-b3eadea4d33e" />
-
----
-
-## 2. Detailed Component Design (with Azure Services)
-
-### 2.1 Web Client Layer
-- **Description:**  
-  User interface built with Blazor Server for menu management, analytics, AI insights, and notifications.
-- **Purpose:**  
-  Deliver a secure, interactive UX for restaurant managers and staff.
-- **Responsibilities:**  
-  - Authenticate users (Azure AD)
-  - Carry tenant context from JWTs in API requests
-  - Render UI modules: Menu Management, Analytics, AI Insights, Notifications
-  - Handle real-time updates with SignalR
-
-- **Azure Services:**
-  - **Azure App Service (Web Apps):** Host the Blazor Server app. Managed, scalable, and secure hosting with zero-downtime deployment.
-  - **Azure SignalR Service:** Managed real-time communication for notifications and live updates.
-
-### 2.2 API Layer
-- **Description:**  
-  ASP.NET Core Web API backend for business logic, data access, and orchestration.
-- **Purpose:**  
-  Expose secure RESTful endpoints and enforce business rules.
-- **Responsibilities:**  
-  - REST endpoints with controllers (OpenAPI docs)
-  - Business logic in services (menus, orders, analytics, reviews, AI)
-  - Data access via repositories (EF Core, multi-tenant)
-  - CQRS (MediatR) for command/query separation
-
-- **Azure Services:**
-  - **Azure App Service (Web Apps):** Host the API backend with autoscaling, slot-based deployments, and integrated CI/CD.
-  - **Azure Key Vault:** Secure storage of API keys, connection strings, and secrets.
-  - **Azure Managed Identity:** Secure, passwordless authentication for services to Azure resources.
-
-### 2.3 AI/Analytics Services
-- **Description:**  
-  Modular AI services for ML-driven forecasts, review analysis, and KPI aggregation.
-- **Purpose:**  
-  Automate data analysis, generate insights, and support menu optimization.
-- **Responsibilities:**  
-  - Orchestrate AI workflows and integrate with Azure Cognitive Services or custom ML models
-  - Run jobs (ForecastJob, SentimentJob, ScoreDishJob)
-  - Async processing (triggered by DB triggers or polling or REST calls)
-  - Store analytics results in tenant-specific tables
-
-- **Azure Services:**
-  - **Azure Functions / Azure Container Apps:** Serverless or containerized execution for background AI jobs, scalable on-demand.
-  - **Azure Machine Learning:** Build, deploy, and manage custom ML models.
-  - **Azure Cognitive Services (Text Analytics, Language, etc.):** For sentiment analysis of reviews and other AI tasks.
-  - **Azure Logic Apps (optional):** For orchestrating complex workflows or integrating with external systems.
-
-### 2.4 Data Storage
-- **Description:**  
-  Multi-model persistence for structured and unstructured data.
-- **Purpose:**  
-  Store, isolate, and serve high-performance data for analytics and operations.
-- **Responsibilities:**  
-  - Tenant-isolated data in relational DB
-  - Fast caching for KPIs and configs
-  - File/object storage for exports, backups
-  - Partitioning and indexing for analytics
-
-- **Azure Services:**
-  - **Azure Database for PostgreSQL:** Managed relational database, schema-per-tenant, built-in backup, scaling, and geo-replication.
-  - **Azure Redis Cache:** Low-latency caching for frequently accessed data and session state.
-  - **Azure Blob Storage:** Durable, scalable storage for files, exports, and backups.
-  - **Azure Cosmos DB (optional):** For future polyglot persistence or unstructured analytics.
-
-### 2.5 Security & Identity
-- **Description:**  
-  Authentication, authorization, and secret management.
-- **Purpose:**  
-  Ensure secure, compliant access control and data protection.
-- **Responsibilities:**  
-  - Azure AD/OIDC user login, OAuth2 for integrations
-  - Enforce RBAC via claims-based policies
-  - Store/manage secrets in Key Vault
-
-- **Azure Services:**
-  - **Azure Active Directory (Entra ID):** Central, cloud-native identity provider for users and admins.
-  - **Azure Key Vault:** Secure, auditable storage for keys, secrets, and certificates.
-  - **Azure Managed Identity:** For service-to-service authentication without secrets.
-
-### 2.6 Monitoring & Observability
-- **Description:**  
-  End-to-end monitoring, logging, and distributed tracing.
-- **Purpose:**  
-  Ensure system health, facilitate rapid troubleshooting, and drive business insights.
-- **Responsibilities:**  
-  - Collect logs and telemetry from all components
-  - Track business and technical metrics
-  - Correlate requests via distributed tracing
-  - Alerting for failures, anomalies, and business KPIs
-
-- **Azure Services:**
-  - **Azure Application Insights:** Deep application performance monitoring, distributed tracing, and log analytics.
-  - **Azure Monitor:** Centralized dashboard for metrics, logs, and alert management.
-  - **Azure Log Analytics:** Query and analyze logs and telemetry across all resources.
-
----
-
-## 3. Data Flows & Sequence Diagrams
-
-### 3.1 Sales Forecast Request
-1. User requests forecast via dashboard (Blazor).
-2. API Layer authenticates, validates context, and triggers a ForecastJob.
-3. AI/Analytics Service retrieves historical sales, calls ML model, stores result in Data Storage.
-4. API Layer/SignalR updates dashboard with latest forecast.
-
-### 3.2 Review Sentiment Analysis
-1. Review submitted via UI.
-2. API stores review and triggers SentimentJob in AI/Analytics.
-3. Analytics Service calls Cognitive Services, updates KPIs in Data Storage.
-4. API Layer/SignalR updates dashboard if negative trend detected.
-
----
-
-## 4. Low-Level System Design Principles—How They’re Met
-
-- **Scalability:** Stateless API, modular services, Azure scaling, event-driven jobs.
-- **Reliability:** Managed services, retries, health checks, managed backups.
-- **Security:** Azure AD, JWT, Key Vault, tenant context.
-- **Performance:** Redis cache, async events, DB indexing, autoscaling.
-- **Maintainability:** Clean architecture, DI, modular projects, OpenAPI docs, code comments.
-- **Extensibility:** Pluggable jobs, extensible endpoints.
-- **Observability:** App Insights, logging, alerts, distributed tracing.
-- **Data Isolation:** Tenant schema separation, RBAC, context-aware queries.
-- **Cost Efficiency:** Serverless/container-based jobs, shared infra, consumption-tier.
-- **UX/Responsiveness:** SignalR for real-time, pre-cached dashboards, fast APIs.
-
----
-
-## 5. Example Directory Structure
-
-```plaintext
-/WebClient
-  /Pages
-  /Components
-/Api
-  /Controllers
-  /Services
-  /Repositories
-/AI
-  /Jobs
-  /Orchestrator
-/Contracts
-/Infrastructure
-  /Persistence
-  /Migrations
-/Security
-/Monitoring
-```
-
----
-
-## 6. Key Sequence Diagrams
-
-- **Forecasting:** User → API → ForecastJob → AI/Analytics Service → DB → API/UI (via SignalR).
-- **Review Analysis:** User → API → SentimentJob → Analytics → DB → API/UI (via SignalR).
-
----
-
-## 7. Extensibility Points
-
-- Add new AI features by creating a new Job Handler under `/AI/Jobs`.
-- Add new endpoints by extending Controllers and Services under `/Api`.
-
---------
-
-# High-Level Smart Menu Optimizer System Design
+## High-Level System Design
 
 <img width="1024" height="1536" alt="image" src="https://github.com/user-attachments/assets/56ee500f-0cb4-4640-b465-221a28c68a60" />
 
----
+### Core Flow
 
-## 1. Web Client Layer
+1. Web client sends request through secure edge entry.
+2. API management/policies validate and route calls.
+3. Application services execute business logic and publish events.
+4. Event bus powers asynchronous AI/analytics workflows.
+5. Data layer persists tenant-scoped business and insight data.
+6. Monitoring captures operational and product health signals.
 
-**Users:** Restaurant managers, admins, or other tenant users.
+### Key Design Principles Met
 
-**Purpose:**  
-Provides an intuitive, tenant-specific interface for managing menus, viewing analytics, and receiving AI-driven recommendations.
-
-**Responsibilities:**
-
-- Display menus, performance metrics, and optimization suggestions.
-- Provide tenant-specific configurations (menu preferences, promotions).
-- Securely submit requests to backend services, carrying tenant context.
-- Visualize sales trend analysis, forecasting charts, and predictive insights.
-
-**Key Points:**
-
-- Multi-tenant aware.
-- Receives aggregated predictions and insights from backend services asynchronously.
-
----
-
-## 2. Front Door (Azure Front Door)
-
-**Purpose:**  
-Acts as the global entry point for requests, providing load balancing, SSL offload, WAF, and routing.
-
-**Responsibilities:**
-
-- Global routing to the nearest regional service instance for low latency.
-- SSL/TLS termination for encryption offloading.
-- Web Application Firewall (WAF) for security (e.g., SQL injection, XSS).
-- Health probes for automatic failover.
-
-**Example Use Case:**  
-A manager in New York accesses the platform; Front Door routes them to the closest regional backend instance while enforcing security policies and encrypting traffic.
+1. Scalability
+2. Reliability & fault tolerance
+3. Security
+4. Performance efficiency
+5. Maintainability
+6. Extensibility
+7. Observability
+8. Data isolation (multi-tenancy)
+9. Cost efficiency
+10. UX responsiveness
 
 ---
 
-## 3. API Management Layer
+## Monitoring & Logging
 
-**Purpose:**  
-Centralizes API management for authentication, rate limiting, and policy enforcement.
-
-**Responsibilities:**
-
-- Authentication & authorization with OAuth2/JWT for multi-tenant access.
-- Rate limiting and throttling to prevent abuse.
-- Policy enforcement (input validation, request transformations).
-- API versioning and documentation for developers or partners.
-
-**Example Use Case:**  
-A third-party integration requests sales analytics. API Management enforces rate limits and validates the API key for the correct tenant.
+- **Application Insights:** request traces, exceptions, custom metrics.
+- **Azure Monitor + Log Analytics:** centralized dashboards and operational alerts.
+- **Health endpoints:** service readiness/liveness checks for runtime confidence.
 
 ---
 
-## 4. Application / Service Layer (Enhanced with AI)
+## Deployment & Infrastructure
 
-**Purpose:**  
-Core business logic, analytics, and AI-driven intelligence.
+Managed with IaC (Bicep/Terraform/ARM) and environment-specific configurations.
 
-**Responsibilities:**
-
-- **Menu & Order Management:** CRUD for menu items and orders.
-- **Analytics & Insights:** Dish performance calculation, KPIs, and optimization suggestions.
-- **Sales Trend Analysis & Forecasting:** Historical sales aggregation, pattern detection, and ML-driven predictions.
-- **Predictive & Prescriptive Analytics:** Identify trends, underperformers, and suggest menu changes/promotions.
-- **Text Analytics & Sentiment Analysis:** Analyze customer reviews for actionable insights.
-- **AI Chat & Recommendation Engine:** ChatGPT-style integration for natural language queries and contextual recommendations.
-- **Tenant Context Propagation:** Ensures all AI insights and predictions respect tenant isolation.
-- **Business Rules Enforcement:** Promote high-margin items, flag low-stock, highlight negative reviews.
-
-**Design Patterns & Architecture:**
-
-- **Service Layer Pattern:** Modular, testable, reusable logic.
-- **Event-Driven AI Processing:** AI tasks (ML predictions, sentiment analysis) are triggered asynchronously via Event Bus.
-- **CQRS for AI Data:** Separate commands (write/update) and queries (read/fetch).
-
-**Example Flow:**
-
-- Tenant requests “Sales Forecast for Next Month.”  
-  The Service Layer fetches historical data → ML model estimates future sales → results stored in the database → visualized on the dashboard.
-
-- Customer reviews arrive → Text Analytics & Sentiment Analysis → triggers Event Bus → Recommendation Service suggests menu changes → updates dashboard.
-
-- Manager asks via ChatGPT: “Which dishes are likely to underperform next week?” → AI model responds with actionable suggestions.
-
-**Integration with Event Bus / Messaging Layer:**
-
-- **Scenario 1:** New review arrives → Event Bus triggers Sentiment Analysis → AI model scores dish → updates performance metrics.
-- **Scenario 2:** High-volume sales data from POS → Event Hub triggers ML model → updates sales forecast asynchronously.
-- **Scenario 3:** Manager asks ChatGPT for recommendation → AI Service consults predictive model → Event Bus updates dashboard asynchronously.
-
-**Key Benefits of AI Integration:**
-
-- Real-time insights for decision-making.
-- Predictive power for menus, inventory, and promotions.
-- Natural language support for enhanced UX.
-- Decoupled, asynchronous AI processing for scalability.
+| Resource Type | Azure Service |
+|---------------|---------------|
+| App Hosting | Azure App Service (Web/API/AI workloads) |
+| Containers | Azure Container Registry |
+| Relational DB | Azure Database for PostgreSQL |
+| Cache | Azure Redis |
+| Eventing | Azure Service Bus / Event Grid |
+| Secret Management | Azure Key Vault |
+| Monitoring | Application Insights / Azure Monitor |
 
 ---
 
-## 5. Event Bus / Messaging Layer (Detailed)
+## Documentation
 
-The Event Bus / Messaging Layer is the backbone of decoupled, scalable, and resilient communication in the Smart Menu Optimizer system. It enables asynchronous processing, system extensibility, and real-time insights by allowing services to communicate through events rather than direct calls. Here’s a detailed breakdown:
+Primary documentation currently lives in this README and is organized by:
 
----
+- Features (app + technical)
+- Architecture (layered + high-level)
+- AI capabilities
+- LLD/CI-CD/DevOps delivery model
+- Deployment, observability, and design rationale
 
-### **Core Purposes**
-
-1. **Decoupling**  
-   Services publish and subscribe to events, so they don’t need to know about each other’s existence or implementation. For example, the Review Service can publish a `ReviewReceived` event, and the Analytics Service can subscribe to it.
-
-2. **Scalability & Resilience**  
-   Event-driven systems naturally scale: services can process messages at their own pace, and new consumer services can be added without changing the event producers.
-
-3. **Reliability**  
-   Supports features like retry policies, dead-letter queues, and persistence, ensuring no data loss even if services are temporarily unavailable.
-
-4. **CQRS Support**  
-   Cleanly separates commands (write operations) and queries (read operations):  
-   - **Commands:** “UpdateSalesForecast”, “ProcessReview”, etc.  
-   - **Events:** “MenuUpdated”, “SalesThresholdBreached”, etc.
+If desired, this can be split into `/docs` files following the same style used in `gallery-manager`.
 
 ---
 
-### **Azure Messaging Services Overview**
-
-- **Azure Service Bus**  
-  - **Queues:** Point-to-point communication for commands (e.g., “ProcessNewOrder”).  
-  - **Topics & Subscriptions:** Publish/subscribe for events (e.g., “ReviewReceived”).
-
-- **Azure Event Grid**  
-  - Lightweight, high-throughput event routing for domain/business events.  
-  - Example: “MenuUpdated”, “SalesThresholdBreached”.
-
-- **Azure Event Hubs** (Optional/Advanced)  
-  - Handles high-volume telemetry/streaming data (e.g., bulk POS sales ingestion).
-
----
-
-### **Key Responsibilities**
-
-1. **Event Publishing**
-   - Services (like Web/API, Review, or POS Ingestion) publish events after significant business actions (e.g., order creation, review submission).
-
-2. **Event Consumption**
-   - Analytics, Forecasting, Notification, and Recommendation services subscribe and react to these events asynchronously.
-
-3. **Command Handling**
-   - Commands are sent via queues to trigger specific actions (e.g., “GenerateForecast”), decoupling the request from immediate execution.
-
-4. **Reliability & Error Handling**
-   - Built-in retry, message dead-lettering, and delayed delivery ensure robust handling of transient failures.
-
-5. **Multi-Tenancy Awareness**
-   - Events and messages carry tenant context, so processing and data updates are isolated to the correct tenant.
-
----
-
-### **Typical Event Flow Examples**
-
-#### **A. Customer Review Submission**
-1. Customer submits a review.
-2. Web/API Layer publishes a `ReviewReceived` event to Event Grid.
-3. Analytics Service consumes this event, analyzes sentiment, and updates dish metrics.
-4. Recommendation Service may publish a `MenuInsightGenerated` event.
-5. Notification Service sends insights or alerts to the manager asynchronously.
-
-#### **B. Sales Data Ingestion and Forecast**
-1. Bulk sales data is ingested (via POS or upload).
-2. Event Hub receives high-throughput sales telemetry.
-3. Forecasting Service listens to events, processes data, and predicts future trends.
-4. Results are written to storage and a `ForecastGenerated` event is published.
-5. Web client is updated with new forecasts.
-
-#### **C. Menu Update**
-1. Manager updates menu items.
-2. API Layer publishes a `MenuUpdated` event to Event Grid.
-3. Analytics, Notification, and Inventory Services consume the event and react accordingly (e.g., recalculate KPIs, alert kitchen, etc.).
-
----
-
-### **Design Patterns & Best Practices**
-
-- **Publisher-Subscriber Pattern:**  
-  Enables many-to-many communication between event producers and consumers.
-
-- **Event Sourcing:**  
-  (Optional, advanced) Persist all events for auditability and replayability.
-
-- **Outbox Pattern:**  
-  Ensures reliable event publishing in the presence of transaction boundaries (avoiding lost updates).
-
-- **Idempotency:**  
-  Event handlers are designed to process repeated events without side effects.
-
-- **Event Contracts:**  
-  Events have well-defined schemas (JSON or Avro) to ensure compatibility between services.
-
----
-
-### **Multi-Tenant Considerations**
-
-- **Tenant Context Propagation:**  
-  Every event/message includes tenant ID or context metadata, ensuring strict data and process isolation.
-
-- **Per-Tenant Subscriptions:**  
-  Optionally, services can subscribe to only those events relevant to specific tenants for efficiency and compliance.
-
----
-
-### **Example Event Definitions (Pseudocode/JSON)**
-
-```json
-{
-  "eventType": "ReviewReceived",
-  "tenantId": "tenant-123",
-  "reviewId": "rev-789",
-  "dishId": "dish-456",
-  "rating": 4,
-  "comment": "Great taste, but a bit salty.",
-  "timestamp": "2025-08-23T03:00:00Z"
-}
-```
-```json
-{
-  "eventType": "SalesThresholdBreached",
-  "tenantId": "tenant-123",
-  "dishId": "dish-456",
-  "salesCount": 300,
-  "threshold": 250,
-  "direction": "above",
-  "period": "2025-W34"
-}
-```
-
----
-
-### **Summary Table**
-
-| Feature                     | Benefit                                  | Example                                  |
-|-----------------------------|------------------------------------------|------------------------------------------|
-| Decoupling                  | Flexible scaling, independent services   | Analytics service added with no API changes |
-| Asynchronous Processing     | Responsive UI, background tasks          | Sentiment analysis triggered after review submission |
-| Reliability                 | No data loss, robust error handling      | Sales events retried on failure          |
-| Multi-Tenancy               | Data isolation, secure event handling    | Tenant context in all events             |
-| CQRS                        | Optimized read/write, flexibility        | Separate “GenerateForecast” (cmd) and “ForecastGenerated” (event) |
-
----
-
-### **Summary**
-
-The Event Bus / Messaging Layer is essential for:
-- Decoupling and scaling services
-- Handling spikes in load and asynchronous tasks (like AI/ML predictions)
-- Ensuring reliability, observability, and tenant data isolation
-- Enabling rich, event-driven features that power real-time insights and recommendations
-
-This architecture provides the flexibility and robustness required for a modern, AI-driven, multi-tenant SaaS platform like Smart Menu Optimizer.
-
-
-## 6. Database Layer (Multi-Tenant)
-
-**Purpose:**  
-Secure, efficient storage of tenant data.
-
-**Responsibilities:**
-
-- Tenant-isolated storage (shared DB, separate schema per tenant).
-- Store menus, orders, reviews, analytics.
-- Optimize with indexing, caching, partitioning.
-- Optionally: separate DB per large tenant.
-
-**Data Flow Example:**  
-Service Layer writes prediction results → stored in tenant schema → accessible by web client for dashboards.
-
----
-
-## 7. Monitoring & Logging
-
-**Purpose:**  
-Reliability and observability.
-
-**Responsibilities:**
-
-- Track performance metrics, errors, anomalies.
-- Audit user/tenant actions.
-- Alert on threshold breaches.
-
-**Tools:** Azure Monitor, Application Insights, Log Analytics.
-
-**Example Use Case:**  
-Anomalous spike in failed orders detected → alert triggered → DevOps investigates.
-
----
-
-# High-Level Flow
-
-1. Web client request → Front Door (routing, WAF, SSL offload)
-2. Routed to API Management (authentication, rate limiting)
-3. Request reaches Service Layer (business logic or event publishing)
-4. Event Bus handles async tasks (analytics, notifications, forecasting)
-5. Database persists tenant data
-6. Monitoring & Logging capture metrics and anomalies
-
----
-
-## How the Solution Meets 10 Essential System Design Principles
-
-1. **Scalability**  
-   - The use of Azure Front Door, Event Bus (Service Bus/Event Grid), and cloud-native hosting (App Service, AKS) enables horizontal and geo-distributed scaling.  
-   - Stateless APIs and modular microservices allow for on-demand scaling of individual components.
-
-2. **Reliability & Fault Tolerance**  
-   - Event-driven architecture with message queues, dead-lettering, and retry policies ensures resilience to transient failures.
-   - Health probes and automatic failover in Azure Front Door, plus redundant databases and services, increase system uptime.
-
-3. **Security**  
-   - Multi-layered security via Azure Front Door (WAF), API Management (authentication, throttling), Azure AD (identity), and tenant-aware APIs.
-   - Secrets are managed in Azure Key Vault; all communications are encrypted.
-
-4. **Performance & Efficiency**  
-   - Caching with Azure Redis and asynchronous processing via Event Bus minimize latency and optimize resource usage.
-   - API Management enables throttling and request shaping for optimal backend load.
-
-5. **Maintainability**  
-   - Clean architecture separates concerns: UI, business logic, data, and infrastructure.
-   - Modular services and event-driven decoupling make it easy to add, update, or replace components.
-
-6. **Extensibility**  
-   - The solution supports plug-and-play AI/analytics modules, new event consumers, and third-party integrations via API Management.
-   - Event-driven patterns allow seamless addition of new features without disrupting existing workflows.
-
-7. **Observability**  
-   - End-to-end monitoring via Azure Monitor and Application Insights.
-   - Centralized logging, metrics, and alerting provide full visibility into system health and behavior.
-
-8. **Data Isolation & Multi-Tenancy**  
-   - Tenant context is propagated at every layer, ensuring strict data and process isolation.
-   - Database schemas and API authorization enforce per-tenant privacy and access controls.
-
-9. **Cost Efficiency**  
-   - On-demand, consumption-based Azure services (Functions, Event Grid, Storage) minimize idle resource expenses.
-   - Multi-tenant design optimizes infrastructure usage.
-
-10. **User Experience & Responsiveness**  
-    - Real-time, interactive dashboards (Blazor) and asynchronous analytics ensure users get timely, actionable insights.
-    - Predictive and natural language features enhance engagement and usability.
-
----
-
-# Key Benefits
-
-- **Global Scalability:**  
-  Front Door + Event Bus = geo-distributed, horizontally scalable architecture.
-
-- **Security:**  
-  API Management, WAF, tenant-aware services provide multi-layer protection.
-
-- **Analytics-Driven:**  
-  Integrated sales trend analysis, prediction, and forecasting.
-
-- **Maintainable & Extensible:**  
-  Service Layer + Event Bus decoupling simplifies feature addition.
-
-- **SaaS Ready:**  
-  Multi-tenant aware, with per-tenant dashboards and predictive insights.
-
-- **Meets Modern System Design Principles:**  
-  The architecture holistically addresses scalability, reliability, security, maintainability, extensibility, observability, data isolation, cost efficiency, and user experience—ensuring a robust foundation for current needs and future growth.
-
+## Design Rationale
+
+- **Business-first AI:** The platform is designed around measurable restaurant outcomes, not generic dashboards.
+- **Layered modularity:** Keeps the system adaptable as features and tenants grow.
+- **Event-driven integration:** Supports asynchronous, scalable analytics and notification flows.
+- **Cloud-native reliability:** Uses managed Azure services for security, uptime, and operational visibility.
+- **Developer-friendly structure:** Strong separation of concerns plus CI/CD practices for sustainable delivery.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Typical stages:
 
 ## Deployment & Infrastructure
 
-Managed with IaC (Bicep/Terraform/ARM) and environment-specific configurations.
+Intended to be managed with IaC (Bicep/Terraform/ARM) and environment-specific configurations. IaC templates are planned but not yet included in the repository.
 
 | Resource Type | Azure Service |
 |---------------|---------------|

--- a/README.md
+++ b/README.md
@@ -161,14 +161,13 @@ Smart Menu Optimizer’s LLD includes both application internals and team delive
 
 ### Component Scope
 
-- Web Client (`/WebClient`)
-- API Layer (`/Api`)
-- AI/Analytics (`/AI`, `/Analytics`)
-- Messaging (`/Messaging`, `/EventBus`)
-- Data (`/Infrastructure`, `/Persistence`)
-- Security (`/Security`, `/Identity`)
-- Observability (cross-cutting)
-- CI/CD & DevOps (`/.github`, `/DevOps`)
+- Server / UI (`/SmartMenuOptim.Server`)
+- Backend API (`/SmartMenuOptim.API`)
+- Domain (`/SmartMenuOptim.Domain`)
+- Infrastructure (`/SmartMenuOptim.Infrastructure`)
+- Shared (`/SmartMenuOptim.Shared`)
+- Tests (`/SmartMenuOptim.Tests`)
+- CI/CD (`/.github/workflows`)
 
 ### Collaboration and Delivery
 


### PR DESCRIPTION
The `database-migrations` GitHub Actions job was failing with error `NETSDK1004: Assets file 'project.assets.json' not found` because NuGet packages were never restored before running `dotnet ef database update`.

## Root Cause

The `database-migrations` (and `apply-prod-migrations`) jobs ran `dotnet ef database update` without a prior `dotnet restore`, so the `obj/project.assets.json` file required by the .NET SDK was never generated.

## Changes Made

Added a `Restore dependencies` step (`dotnet restore SmartMenuOptim.API/SmartMenuOptim.API.csproj`) immediately before the `Apply EF Core Migrations` step in both affected jobs in `.github/workflows/ci-cd.yml`:

- **`database-migrations`** — the job that was failing in CI
- **`apply-prod-migrations`** — same missing step that would cause identical failures against the production database

## Testing

- ✅ Secret scan passed — no secrets detected in changed files
- ✅ Code review passed with no issues found